### PR TITLE
Add vrf into the msvc build

### DIFF
--- a/builds/msvc/vs2019/libsodium/libsodium.vcxproj
+++ b/builds/msvc/vs2019/libsodium/libsodium.vcxproj
@@ -114,6 +114,13 @@
     <ClCompile Include="..\..\..\..\src\libsodium\crypto_pwhash\scryptsalsa208sha256\nosse\pwhash_scryptsalsa208sha256_nosse.c" />
     <ClCompile Include="..\..\..\..\src\libsodium\crypto_pwhash\scryptsalsa208sha256\sse\pwhash_scryptsalsa208sha256_sse.c" />
     <ClCompile Include="..\..\..\..\src\libsodium\crypto_verify\sodium\verify.c" />
+    <ClCompile Include="..\..\..\..\src\libsodium\crypto_vrf\crypto_vrf.c" />
+    <ClCompile Include="..\..\..\..\src\libsodium\crypto_vrf\ietfdraft03\vrf.c" />
+    <ClCompile Include="..\..\..\..\src\libsodium\crypto_vrf\ietfdraft03\verify.c" />
+    <ClCompile Include="..\..\..\..\src\libsodium\crypto_vrf\ietfdraft03\prove.c" />
+    <ClCompile Include="..\..\..\..\src\libsodium\crypto_vrf\ietfdraft13\vrf.c" />
+    <ClCompile Include="..\..\..\..\src\libsodium\crypto_vrf\ietfdraft13\verify.c" />
+    <ClCompile Include="..\..\..\..\src\libsodium\crypto_vrf\ietfdraft13\prove.c" />
     <ClCompile Include="..\..\..\..\src\libsodium\crypto_auth\crypto_auth.c" />
     <ClCompile Include="..\..\..\..\src\libsodium\crypto_auth\hmacsha512\auth_hmacsha512.c" />
     <ClCompile Include="..\..\..\..\src\libsodium\crypto_auth\hmacsha512256\auth_hmacsha512256.c" />
@@ -183,6 +190,7 @@
     <ClCompile Include="..\..\..\..\src\libsodium\crypto_core\ed25519\core_ed25519.c" />
     <ClCompile Include="..\..\..\..\src\libsodium\crypto_core\ed25519\core_ristretto255.c" />
     <ClCompile Include="..\..\..\..\src\libsodium\crypto_core\ed25519\ref10\ed25519_ref10.c" />
+    <ClCompile Include="..\..\..\..\src\libsodium\crypto_core\ed25519\core_h2c.c" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\..\..\src\libsodium\crypto_generichash\blake2b\ref\blake2b-load-sse2.h" />
@@ -232,6 +240,9 @@
     <ClInclude Include="..\..\..\..\src\libsodium\include\sodium\crypto_scalarmult.h" />
     <ClInclude Include="..\..\..\..\src\libsodium\include\sodium\crypto_pwhash.h" />
     <ClInclude Include="..\..\..\..\src\libsodium\include\sodium\crypto_verify_16.h" />
+    <ClInclude Include="..\..\..\..\src\libsodium\include\sodium\crypto_vrf.h" />
+    <ClInclude Include="..\..\..\..\src\libsodium\include\sodium\crypto_vrf_ietfdraft03.h" />
+    <ClInclude Include="..\..\..\..\src\libsodium\include\sodium\crypto_vrf_ietfdraft13.h" />
     <ClInclude Include="..\..\..\..\src\libsodium\include\sodium\crypto_stream_chacha20.h" />
     <ClInclude Include="..\..\..\..\src\libsodium\include\sodium\crypto_stream_xsalsa20.h" />
     <ClInclude Include="..\..\..\..\src\libsodium\include\sodium\crypto_core_hsalsa20.h" />
@@ -315,6 +326,7 @@
     <ClInclude Include="..\..\..\..\src\libsodium\crypto_core\ed25519\ref10\fe_51\fe.h" />
     <ClInclude Include="..\..\..\..\src\libsodium\crypto_core\ed25519\ref10\fe_51\base2.h" />
     <ClInclude Include="..\..\..\..\src\libsodium\crypto_core\ed25519\ref10\fe_51\base.h" />
+    <ClInclude Include="..\..\..\..\src\libsodium\crypto_core\ed25519\core_h2c.h" />
     <ClInclude Include="..\..\resource.h" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
When trying to link against this library on windows, I'm missing the vrf functionality.

```
= note: libpallas_crypto-827818e2d2f7ab6a.rlib(pallas_crypto-827818e2d2f7ab6a.pallas_crypto.51882408ae0a1925-cgu.0.rcgu.o) : error LNK2019: unresolved external symbol crypto_vrf_ietfdraft03_prove referenced in function _ZN13pallas_crypto3vrf23sodium_crypto_vrf_prove17hd36ff3f3bf63302eE

          libpallas_crypto-827818e2d2f7ab6a.rlib(pallas_crypto-827818e2d2f7ab6a.pallas_crypto.51882408ae0a1925-cgu.0.rcgu.o) : error LNK2019: unresolved external symbol crypto_vrf_ietfdraft03_proof_to_hash referenced in function _ZN13pallas_crypto3vrf31sodium_crypto_vrf_proof_to_hash17h277ce868fdfebce6E

          libpallas_crypto-827818e2d2f7ab6a.rlib(pallas_crypto-827818e2d2f7ab6a.pallas_crypto.51882408ae0a1925-cgu.0.rcgu.o) : error LNK2019: unresolved external symbol crypto_vrf_ietfdraft03_verify referenced in function _ZN13pallas_crypto3vrf24sodium_crypto_vrf_verify17h7acc9a0f958c23d2E

          D:\a\pallas\pallas\target\debug\deps\pallas_utxorpc-c2d97b5d1c68acee.exe : fatal error LNK1120: 3 unresolved externals
```          